### PR TITLE
Update jquery.ui.datepicker.js

### DIFF
--- a/ui/jquery.ui.datepicker.js
+++ b/ui/jquery.ui.datepicker.js
@@ -1059,6 +1059,8 @@ $.extend(Datepicker.prototype, {
 				month++;
 				day -= dim;
 			} while (true);
+		}else if(day === -1){ // to support month picker which dateFormat is 'yy-mm';
+			day = 1;
 		}
 		var date = this._daylightSavingAdjust(new Date(year, month - 1, day));
 		if (date.getFullYear() != year || date.getMonth() + 1 != month || date.getDate() != day)


### PR DESCRIPTION
to support month picker which dateFormat is 'yy-mm';
or the value '2015-01' will not be set to datepicker. and the defaultMonth/defaultDate will be used.

ref:
 monthPicker code example http://thiamteck.blogspot.com/2011/03/jquery-ui-datepicker-with-month-and.html
